### PR TITLE
connect the OpenAPI Context with Loggers from Symfony

### DIFF
--- a/ApiDocGenerator.php
+++ b/ApiDocGenerator.php
@@ -83,7 +83,7 @@ final class ApiDocGenerator
             }
         }
 
-        $generator = new Generator();
+        $generator = new Generator($this->logger);
         // Remove OperationId processor as we use a lot of generated annotations which do not have enough information in their context
         // to generate these ids properly.
         // @see https://github.com/zircote/swagger-php/issues/1153


### PR DESCRIPTION
Fix #2077. Very simple but useful change because there is no other way achieve this e.g by decorating `ApiDocGenerator`. 

The patch sound quiet simple and was already suggested in the issue. Did I miss something ? 

